### PR TITLE
test(sms configuration): add draft feature files

### DIFF
--- a/cypress/drafts/sms_gateway/Add_bulksms_gateway.feature
+++ b/cypress/drafts/sms_gateway/Add_bulksms_gateway.feature
@@ -1,0 +1,23 @@
+Feature: BulkSMS gateway configurations can be added
+
+  Background:
+    Given the user navigated to the gateway configuration page
+
+  Scenario: The user successfully adds a BulkSMS gateway
+    When the user clicks on the add gateway button
+    And the user changes the gateway type to BulkSMS
+    And the user fills in the form data
+      | name | username | password |
+      | foo  | bar      | baz      |
+    And the user clicks on the add button
+    Then the user should be redirected to the gateway configuration page
+    And the newly added gateway should be listed in the table at the bottom
+
+  Scenario: The user wants to add a BulkSMS gateway
+            but doesn't supply the required data
+    When the user clicks on the add gateway button
+    And the user changes the gateway type to BulkSMS
+    And the user fills in incomplete form data
+    And the user clicks on the add button
+    Then the form does not submit
+    And an error message should be shown at the fields that are required but empty

--- a/cypress/drafts/sms_gateway/Add_clickatell_gateway.feature
+++ b/cypress/drafts/sms_gateway/Add_clickatell_gateway.feature
@@ -1,0 +1,22 @@
+Feature: Clickatell Gateway configurations can be added
+
+  Background:
+    Given the user navigated to the gateway configuration page
+
+  Scenario: The user successfully adds a Clickatell gateway
+    When the user clicks on the add gateway button
+    And the user changes the gateway type to Clickatell
+    And the user fills in the form data
+      | name | username | password | authToken |
+      | foo  | bar      | baz      | foobar    |
+    And the user clicks on the add button
+    Then the user should be redirected to the gateway configuration page
+    And the newly added gateway should be listed in the table at the bottom
+
+  Scenario: The user wants to add a Clickatell gateway but doesn't supply the required data
+    When the user clicks on the add gateway button
+    And the user changes the gateway type to Clickatell
+    And the user fills in incomplete form data
+    And the user clicks on the add button
+    Then the form does not submit
+    And an error message should be shown at the fields that are required but empty

--- a/cypress/drafts/sms_gateway/Add_generic_gateway.feature
+++ b/cypress/drafts/sms_gateway/Add_generic_gateway.feature
@@ -1,0 +1,33 @@
+Feature: Generic gateway configurations can be added
+
+  Background:
+    Given the user navigated to the gateway configuration page
+
+  Scenario: The user opens the add form
+    When the user clicks on the add gateway button
+    Then the add gateway form should be displayed
+    And the default gateway type is "generic"
+
+  Scenario: The user successfully adds a generic gateway
+    When the user clicks on the add gateway button
+    And the user fills in the form data
+      | name | messageParameter | recipientParameter | urlTemplate |
+      | foo  | bar              | baz                | foobar      |
+    And the user clicks on the add button
+    Then the user should be redirected to the gateway configuration page
+    And the newly added gateway should be listed in the table at the bottom
+
+  Scenario Outline: The user wants to add a generic gateway but doesn't supply the required data
+    When the user clicks on the add gateway button
+    And the user fills in incomplete form data
+    And the user clicks on the add button
+    Then the form does not submit
+    And an error message should be shown at the invalid field
+
+  Scenario: The user adds a generic gateway with custom key-value pairs
+    Given the user adds a generic gateway configuration
+    When the user clicks on the "add more" button
+    Then the key/value form should appear
+    When the user enters values for the key and value
+    And the user submits the form
+    Then the additional key/value pair should be send to the endpoint

--- a/cypress/drafts/sms_gateway/Delete_gateway.feature
+++ b/cypress/drafts/sms_gateway/Delete_gateway.feature
@@ -1,0 +1,20 @@
+Feature: Gateway configurations can be deleted
+
+  Background:
+    Given the user navigated to the gateway configuration page
+
+  Scenario: The user deletes the first gateway configuration
+    Given there are some gateway configurations
+    When the user clicks on the delete button in the first row
+    Then a confirmation model should pop up
+    When the user confirms the deletion
+    Then the confirmation model should close
+    And the first row should have been deleted
+
+  Scenario: The user attempts to delete the first gateway but cancels the process
+    Given there are some gateway configurations
+    When the user clicks on the delete button in the first row
+    Then a confirmation model should pop up
+    When the user cancels the deletion
+    Then the confirmation modal should close
+    And the first row should still exist

--- a/cypress/drafts/sms_gateway/Generic_gateway_custom_key-value_pairs.feature
+++ b/cypress/drafts/sms_gateway/Generic_gateway_custom_key-value_pairs.feature
@@ -1,0 +1,58 @@
+Feature: Generic gateway configurations can have custom key/value pairs
+
+  Background:
+    Given the user navigated to the gateway configuration page
+
+  Scenario Outline: The user adds a standard key value pair
+    Given the user is <operation> a generic gateway configuration
+    When the user clicks on the "add more" button
+    Then the key/value form should appear
+    When the user enters values for the key and value
+    And the user submits the form
+    Then the additional key/value pair should be sent to the endpoint
+
+    Examples:
+      | operation |
+      | editing   |
+      | adding    |
+
+  Scenario Outline: The user adds a confidential key value pair
+    Given the user is <operation> a generic gateway configuration
+    When the user clicks on the "add more" button
+    Then the key/value form should appear
+    When the user enters values for the key and value
+    And checks the "confidential" checkbox
+    And the user submits the form
+    Then the additional key/value pair should be sent to the endpoint
+    And the request parameters have the "confidential" flag set to true
+
+    Examples:
+      | operation |
+      | editing   |
+      | adding    |
+
+  Scenario Outline: The user adds a key value pair as header
+    Given the user is <operation> a generic gateway configuration
+    When the user clicks on the "add more" button
+    Then the key/value form should appear
+    When the user enters values for the key and value
+    And checks the "header" checkbox
+    And the user submits the form
+    Then the additional key/value pair should be sent to the endpoint
+    And the request parameters have the "header" flag set to true
+
+    Examples:
+      | operation |
+      | editing   |
+      | adding    |
+
+  Scenario: The user adds multiple key value pairs
+    Given the user is <operation> a generic gateway configuration
+    And the user has added multiple key value pairs
+    When the user successfully submits the form
+    Then all provided key value pairs should be sent to the endpoint
+
+    Examples:
+      | operation |
+      | editing   |
+      | adding    |

--- a/cypress/drafts/sms_gateway/List_gateways.feature
+++ b/cypress/drafts/sms_gateway/List_gateways.feature
@@ -1,0 +1,21 @@
+Feature: All gateways should be listed
+
+  Background:
+    Given the user navigated to the gateway configuration page
+
+  Scenario: No gateways have been configured yet
+    Given there are no gateways
+    Then no table should be displayed
+
+  Scenario: Some gateways have been configured
+    Given some gateways exist
+    Then the gateways are rendered as tabular data
+    And each row has the following cells
+      | name      |
+      | label     |
+      | operation |
+    And the operation cell should include actions
+      | action          |
+      | Mark as default |
+      | Edit            |
+      | Delete          |

--- a/cypress/drafts/sms_gateway/Update_gateway.feature
+++ b/cypress/drafts/sms_gateway/Update_gateway.feature
@@ -1,0 +1,36 @@
+Feature: Generic gateway configurations can be edited and updated
+
+  Background:
+    Given the user navigated to the gateway configuration page
+
+  Scenario: The user opens the update form of a generic gateway configuration
+    Given there are some generic gateway configurations
+    When the user clicks on the update button in the first row
+    Then the app should navigate to the update form
+    And the input fields contain the information of the chosen gateway configuration
+
+  Scenario Outline: The user changes a field in the first generic gateway configuration
+    Given the user is editing a generic gateway configuration
+    When the user changes the <field> field's value to another valid value
+    And submits the form
+    Then the user should be redirected to the gateway configuration page
+
+    Examples:
+      | field              |
+      | messageParameter   |
+      | recipientParameter |
+      | urlTemplate        |
+
+  Scenario Outline: The user changes a field in the first generic gateway
+                    configuration to an invalid value
+    Given the user is editing a generic gateway configuration
+    When the user changes the <field> field's value to another invalid value
+    And submits the form
+    Then the form does not submit
+    And an error message should be shown at the invalid field
+
+    Examples:
+      | field              |
+      | messageParameter   |
+      | recipientParameter |
+      | urlTemplate        |


### PR DESCRIPTION
This PR will add the feature files that describe the behavior of the "SMS Gateway" (previously "Gateway Configuration") section.

## ToDos

- [x] Add feature files for existing behavior
- [x] No "text" option when adding new key/value pairs
- [x] Use "Confidential" instead of "password"
- [ ] Rethink "Mark as default"
  I don't know what's planned here. I'd propose we do changes like these in a different interation. The quickest way to move all core-apps to the platform stack is by not changing anything.
- [ ] Add checkbox for "Encode"
  Not sure what this should do. Can this be en-/disabled per key/value per or is it a setting for the gateway itself?