### PR TITLE
fix: handle missing data

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-09-03T08:01:29.787Z\n"
-"PO-Revision-Date: 2020-09-03T08:01:29.787Z\n"
+"POT-Creation-Date: 2020-09-03T12:51:22.604Z\n"
+"PO-Revision-Date: 2020-09-03T12:51:22.604Z\n"
 
 msgid "Dataset"
 msgstr ""
@@ -235,6 +235,12 @@ msgstr ""
 msgid "Something went wrong whilst saving gateways"
 msgstr ""
 
+msgid "Gateway not found"
+msgstr ""
+
+msgid "The requested gateway could not be loaded"
+msgstr ""
+
 msgid "Something went wrong whilst saving the gateway"
 msgstr ""
 
@@ -249,6 +255,14 @@ msgid ""
 msgstr ""
 
 msgid "Delete selected"
+msgstr ""
+
+msgid "No gateways found"
+msgstr ""
+
+msgid ""
+"It looks like there aren't any configured gateways, or they couldn't be "
+"loaded."
 msgstr ""
 
 msgid "Filter by status"
@@ -356,6 +370,12 @@ msgstr ""
 msgid "Edit command"
 msgstr ""
 
+msgid "Unrecognised parser type"
+msgstr ""
+
+msgid "Could not find the requested parser type"
+msgstr ""
+
 msgid "Add command"
 msgstr ""
 
@@ -363,4 +383,7 @@ msgid "Commands"
 msgstr ""
 
 msgid "Sms command"
+msgstr ""
+
+msgid "No commands to display"
 msgstr ""

--- a/src/views/gateway_configuration/GatewayConfigFormEdit.js
+++ b/src/views/gateway_configuration/GatewayConfigFormEdit.js
@@ -107,10 +107,12 @@ export const GatewayConfigFormEdit = () => {
         }
     }
 
+    const hasGateway = data?.gateway
+
     return (
         <div data-test={dataTest('views-gatewayconfigformedit')}>
             <PageHeadline>{i18n.t('Edit gateway')}</PageHeadline>
-            {data?.gateway && (
+            {hasGateway ? (
                 <div
                     data-test={dataTest(
                         'views-gatewayconfigformedit-formcontainer'
@@ -149,6 +151,10 @@ export const GatewayConfigFormEdit = () => {
                         />
                     )}
                 </div>
+            ) : (
+                <NoticeBox error title={i18n.t('Gateway not found')}>
+                    {i18n.t('The requested gateway could not be loaded')}
+                </NoticeBox>
             )}
         </div>
     )

--- a/src/views/gateway_configuration/GatewayConfigList.js
+++ b/src/views/gateway_configuration/GatewayConfigList.js
@@ -83,6 +83,8 @@ export const GatewayConfigList = () => {
         )
     }
 
+    const hasGateways = data?.gateways?.gateways
+
     return (
         <div
             className={styles.container}
@@ -106,7 +108,7 @@ export const GatewayConfigList = () => {
                 disableDelete={!checkedGateways.length || loadingDelete}
             />
 
-            {data?.gateways?.gateways && (
+            {hasGateways ? (
                 <GatewayList
                     processing={loading}
                     checkedGateways={checkedGateways}
@@ -114,6 +116,12 @@ export const GatewayConfigList = () => {
                     gateways={data.gateways.gateways}
                     onMakeDefaultClick={onMakeDefaultClick}
                 />
+            ) : (
+                <NoticeBox info title={i18n.t('No gateways found')}>
+                    {i18n.t(
+                        "It looks like there aren't any configured gateways, or they couldn't be loaded."
+                    )}
+                </NoticeBox>
             )}
 
             {showDeleteDialog && (

--- a/src/views/gateway_configuration/GatewayConfigList.js
+++ b/src/views/gateway_configuration/GatewayConfigList.js
@@ -83,7 +83,7 @@ export const GatewayConfigList = () => {
         )
     }
 
-    const hasGateways = data?.gateways?.gateways
+    const hasGateways = !!data?.gateways?.gateways?.length
 
     return (
         <div

--- a/src/views/received_sms_list/ReceivedSmsList.js
+++ b/src/views/received_sms_list/ReceivedSmsList.js
@@ -70,6 +70,8 @@ const ReceivedSmsList = () => {
         )
     }
 
+    const messages = data?.inboundSms?.inboundsmss || []
+
     return (
         <div data-test={dataTest('views-receivedsmslist')}>
             <PageHeadline>{RECEIVED_SMS_LIST_LABEL}</PageHeadline>
@@ -81,15 +83,15 @@ const ReceivedSmsList = () => {
                 />
             </div>
             <div>
-                {data && (
+                {
                     <SmsTable
-                        messages={data.inboundSms.inboundsmss}
+                        messages={messages}
                         pager={data.inboundSms.pager}
                         selectedIds={selectedIds}
                         setSelectedIds={setSelectedIds}
                         refetchList={refetch}
                     />
-                )}
+                }
             </div>
         </div>
     )

--- a/src/views/sent_sms_list/SentSmsList.js
+++ b/src/views/sent_sms_list/SentSmsList.js
@@ -99,6 +99,8 @@ export const SentSmsList = () => {
         },
     }
 
+    const smses = data?.sms?.outboundsmss || []
+
     return (
         <RefetchSms.Provider value={context}>
             <PageHeadline>{SENT_SMS_LIST_LABEL}</PageHeadline>
@@ -109,7 +111,7 @@ export const SentSmsList = () => {
                 </div>
             </div>
             <SmsTable
-                smses={data.sms.outboundsmss}
+                smses={smses}
                 cleanSelected={cleanSelected}
                 allSelected={allSelected}
                 selected={selected}

--- a/src/views/sms_commands/SmsCommandFormEdit.js
+++ b/src/views/sms_commands/SmsCommandFormEdit.js
@@ -56,8 +56,6 @@ export const SmsCommandFormEdit = () => {
     const parserType = data?.smsCommand[FIELD_COMMAND_PARSER_NAME]
     const isParser = isParserType.bind(null, parserType)
 
-    // If it's possible to not have data we should handle that as well
-
     return (
         <div>
             <PageHeadline>{i18n.t('Edit command')}</PageHeadline>
@@ -109,6 +107,12 @@ export const SmsCommandFormEdit = () => {
                     commandId={id}
                     onAfterChange={() => history.push(SMS_COMMAND_LIST_PATH)}
                 />
+            )}
+
+            {!parserType && (
+                <NoticeBox error title={i18n.t('Unrecognised parser type')}>
+                    {i18n.t('Could not find the requested parser type')}
+                </NoticeBox>
             )}
         </div>
     )

--- a/src/views/sms_commands/SmsCommandList.js
+++ b/src/views/sms_commands/SmsCommandList.js
@@ -125,6 +125,7 @@ export const SmsCommandList = () => {
 
     const allChecked =
         checkedSmsCommands.length === data?.smsCommands?.smsCommands?.length
+    const hasCommands = data?.smsCommands?.smsCommands?.length > 0
 
     return (
         <div data-test={dataTest('views-smscommandlist')}>
@@ -162,45 +163,55 @@ export const SmsCommandList = () => {
                     </TableRowHead>
                 </TableHead>
                 <TableBody>
-                    {data?.smsCommands?.smsCommands?.map(
-                        ({ id, displayName, parserType }) => (
-                            <TableRow key={id}>
-                                <TableCell className={styles.checkbox}>
-                                    <Checkbox
-                                        checked={
-                                            !!checkedSmsCommands.find(
-                                                ({ id: checkedId }) =>
-                                                    id === checkedId
-                                            )
-                                        }
-                                        onChange={() =>
-                                            toggleSmsCommand({
-                                                id,
-                                                displayName,
-                                            })
-                                        }
-                                    />
-                                </TableCell>
+                    {hasCommands ? (
+                        data?.smsCommands?.smsCommands?.map(
+                            ({ id, displayName, parserType }) => (
+                                <TableRow key={id}>
+                                    <TableCell className={styles.checkbox}>
+                                        <Checkbox
+                                            checked={
+                                                !!checkedSmsCommands.find(
+                                                    ({ id: checkedId }) =>
+                                                        id === checkedId
+                                                )
+                                            }
+                                            onChange={() =>
+                                                toggleSmsCommand({
+                                                    id,
+                                                    displayName,
+                                                })
+                                            }
+                                        />
+                                    </TableCell>
 
-                                <TableCell>{displayName}</TableCell>
+                                    <TableCell>{displayName}</TableCell>
 
-                                <TableCell>
-                                    {getLabelByParserTypes(parserType)}
-                                </TableCell>
+                                    <TableCell>
+                                        {getLabelByParserTypes(parserType)}
+                                    </TableCell>
 
-                                <TableCell className={styles.editButtonCell}>
-                                    <Button
-                                        onClick={() =>
-                                            history.push(
-                                                `${SMS_COMMAND_FORM_EDIT_PATH_STATIC}/${id}`
-                                            )
-                                        }
+                                    <TableCell
+                                        className={styles.editButtonCell}
                                     >
-                                        {i18n.t('Edit')}
-                                    </Button>
-                                </TableCell>
-                            </TableRow>
+                                        <Button
+                                            onClick={() =>
+                                                history.push(
+                                                    `${SMS_COMMAND_FORM_EDIT_PATH_STATIC}/${id}`
+                                                )
+                                            }
+                                        >
+                                            {i18n.t('Edit')}
+                                        </Button>
+                                    </TableCell>
+                                </TableRow>
+                            )
                         )
+                    ) : (
+                        <TableRow>
+                            <TableCell colSpan="4" className={styles.noResults}>
+                                {i18n.t('No commands to display')}
+                            </TableCell>
+                        </TableRow>
                     )}
                 </TableBody>
             </Table>

--- a/src/views/sms_commands/SmsCommandList.module.css
+++ b/src/views/sms_commands/SmsCommandList.module.css
@@ -5,3 +5,9 @@
 .checkbox {
     width: 1px;
 }
+
+.noResults {
+    color: var(--colors-grey700);
+    text-align: center;
+    font-style: italic;
+}


### PR DESCRIPTION
This adds a couple of fallbacks in case we get back unexpected data.

Notes

- For the SmsCommandFormEdit it's still possible to have a recognised parser type, but not have a case for that type. Ideally that should also be covered.