### PR TITLE
fix: wrap modal children in form to fix submit

### DIFF
--- a/src/smsCommandFields/FieldDataElementWithCategoryOptionComboFormula.js
+++ b/src/smsCommandFields/FieldDataElementWithCategoryOptionComboFormula.js
@@ -90,17 +90,16 @@ export const FieldDataElementWithCategoryOptionComboFormula = ({
         <Form onSubmit={onSubmit} initialValues={initialValues}>
             {({ handleSubmit }) => (
                 <Modal>
-                    <ModalTitle>
-                        {i18n.t('Formula for {{combo}}', { combo })}
-                    </ModalTitle>
-
-                    <ModalContent>
-                        <form
-                            onSubmit={event => {
-                                event.stopPropagation()
-                                handleSubmit(event)
-                            }}
-                        >
+                    <form
+                        onSubmit={event => {
+                            event.stopPropagation()
+                            handleSubmit(event)
+                        }}
+                    >
+                        <ModalTitle>
+                            {i18n.t('Formula for {{combo}}', { combo })}
+                        </ModalTitle>
+                        <ModalContent>
                             <FormRow>
                                 <Field
                                     required
@@ -144,24 +143,23 @@ export const FieldDataElementWithCategoryOptionComboFormula = ({
                                     </NoticeBox>
                                 </FormRow>
                             )}
-                        </form>
-                    </ModalContent>
+                        </ModalContent>
+                        <ModalActions>
+                            <ButtonStrip>
+                                <Button onClick={onRemove}>
+                                    {i18n.t('Remove')}
+                                </Button>
 
-                    <ModalActions>
-                        <ButtonStrip>
-                            <Button onClick={onRemove}>
-                                {i18n.t('Remove')}
-                            </Button>
+                                <Button onClick={onClose}>
+                                    {i18n.t('Cancel')}
+                                </Button>
 
-                            <Button onClick={onClose}>
-                                {i18n.t('Cancel')}
-                            </Button>
-
-                            <Button type="submit" primary>
-                                {i18n.t('Save')}
-                            </Button>
-                        </ButtonStrip>
-                    </ModalActions>
+                                <Button type="submit" primary>
+                                    {i18n.t('Save')}
+                                </Button>
+                            </ButtonStrip>
+                        </ModalActions>
+                    </form>
                 </Modal>
             )}
         </Form>


### PR DESCRIPTION
The submit event from the form submit button couldn't be caught be the form, because the form wasn't a parent of the button. So I've moved the form up in the hierarchy, wrapping all the modal children, so that we can still use all the modal components for styling, whilst also allowing the form to catch the event. I checked the styling and it's the same as it was before this change.