### PR TITLE
fix: routing

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import { BrowserRouter, Route, Switch } from 'react-router-dom'
+import { HashRouter, Route, Switch, Redirect } from 'react-router-dom'
 import { CssVariables } from '@dhis2/ui'
 import React from 'react'
 import styles from './App.module.css'
@@ -24,14 +24,13 @@ import {
     SentSmsList,
     HOME_PATH,
     Home,
-    NoMatch,
 } from './views'
 import { dataTest } from './dataTest'
 
 const App = () => (
     <AlertHandler>
         <CssVariables spacers colors />
-        <BrowserRouter>
+        <HashRouter>
             <div className={styles.container} data-test={dataTest('app')}>
                 <div className={styles.sidebar}>
                     <Navigation />
@@ -93,11 +92,11 @@ const App = () => (
                             component={ReceivedSmsList}
                         />
 
-                        <Route component={NoMatch} />
+                        <Redirect from="*" to={HOME_PATH} />
                     </Switch>
                 </main>
             </div>
-        </BrowserRouter>
+        </HashRouter>
     </AlertHandler>
 )
 

--- a/src/views/NoMatch.js
+++ b/src/views/NoMatch.js
@@ -1,8 +1,0 @@
-import React from 'react'
-import { dataTest } from '../dataTest'
-
-export const NoMatch = () => (
-    <div data-test={dataTest('views-nomatch')}>
-        <h1>404</h1>
-    </div>
-)

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -1,4 +1,3 @@
-export * from './NoMatch'
 export * from './home/Home'
 export * from './gateway_configuration/GatewayConfigList'
 export * from './gateway_configuration/GatewayConfigFormEdit'


### PR DESCRIPTION
Note: this should eventually be merged to the patch branch, I assume. Which we should talk to Phil about first.

- [x] Fix index.html not matching any routes
- [x] Fix router not working when the app is served from a subdirectory

I'm using the approach used in the [import-export app](https://github.com/dhis2/import-export-app/blob/master/src/components/Router/Router.js) as well, which uses a hash router. All unmatched routes are redirected to home, so I've removed the NoMatch view.