### PR TITLE
fix(event registration sms command form): add program stage field

### DIFF
--- a/src/dataSet/FieldDataSetWithAutoLoad.js
+++ b/src/dataSet/FieldDataSetWithAutoLoad.js
@@ -1,3 +1,4 @@
+import { hasValue } from '@dhis2/ui'
 import { PropTypes } from '@dhis2/prop-types'
 import React from 'react'
 
@@ -6,6 +7,7 @@ import { useReadDataSetsQuery } from './useReadDataSetsQuery'
 
 export const FieldDataSetWithAutoLoad = ({ required }) => {
     const { loading, error, data } = useReadDataSetsQuery()
+    const validate = required ? hasValue : undefined
 
     if (loading) {
         return (
@@ -14,6 +16,7 @@ export const FieldDataSetWithAutoLoad = ({ required }) => {
                 showLoadingStatus
                 required={required}
                 dataSets={[]}
+                validate={validate}
             />
         )
     }
@@ -25,6 +28,7 @@ export const FieldDataSetWithAutoLoad = ({ required }) => {
                 disabled
                 programs={[]}
                 errorText={error.message}
+                validate={validate}
             />
         )
     }
@@ -35,7 +39,13 @@ export const FieldDataSetWithAutoLoad = ({ required }) => {
         value: id,
     }))
 
-    return <FieldDataSet required={required} dataSets={options} />
+    return (
+        <FieldDataSet
+            required={required}
+            dataSets={options}
+            validate={validate}
+        />
+    )
 }
 
 FieldDataSetWithAutoLoad.defaultProps = {

--- a/src/program/FieldProgramWithAutoLoad.js
+++ b/src/program/FieldProgramWithAutoLoad.js
@@ -1,3 +1,4 @@
+import { hasValue } from '@dhis2/ui'
 import { PropTypes } from '@dhis2/prop-types'
 import React from 'react'
 
@@ -7,6 +8,7 @@ import { useReadProgramsQuery } from './useReadProgramsQuery'
 export const FieldProgramWithAutoLoad = ({ required, registration }) => {
     const variables = { registration }
     const { loading, error, data } = useReadProgramsQuery({ variables })
+    const validate = required ? hasValue : undefined
 
     if (loading) {
         return (
@@ -15,6 +17,7 @@ export const FieldProgramWithAutoLoad = ({ required, registration }) => {
                 loading
                 showLoadingStatus
                 programs={[]}
+                validate={validate}
             />
         )
     }
@@ -26,6 +29,7 @@ export const FieldProgramWithAutoLoad = ({ required, registration }) => {
                 disabled
                 programs={[]}
                 errorText={error.message}
+                validate={validate}
             />
         )
     }
@@ -36,7 +40,13 @@ export const FieldProgramWithAutoLoad = ({ required, registration }) => {
         value: id,
     }))
 
-    return <FieldProgram required={required} programs={options} />
+    return (
+        <FieldProgram
+            required={required}
+            programs={options}
+            validate={validate}
+        />
+    )
 }
 
 FieldProgramWithAutoLoad.defaultProps = {

--- a/src/programStage/FieldProgramStageWithAutoLoad.js
+++ b/src/programStage/FieldProgramStageWithAutoLoad.js
@@ -1,3 +1,4 @@
+import { hasValue } from '@dhis2/ui'
 import { PropTypes } from '@dhis2/prop-types'
 import React, { useEffect } from 'react'
 
@@ -8,6 +9,7 @@ export const FieldProgramStageWithAutoLoad = ({ required, programId }) => {
     const { loading, error, data, refetch } = useReadProgramStagesQuery({
         lazy: true,
     })
+    const validate = required ? hasValue : undefined
 
     useEffect(() => {
         if (programId) refetch({ programId })
@@ -15,7 +17,12 @@ export const FieldProgramStageWithAutoLoad = ({ required, programId }) => {
 
     if (loading) {
         return (
-            <FieldProgramStage loading required={required} programStages={[]} />
+            <FieldProgramStage
+                loading
+                required={required}
+                programStages={[]}
+                validate={validate}
+            />
         )
     }
 
@@ -26,6 +33,7 @@ export const FieldProgramStageWithAutoLoad = ({ required, programId }) => {
                 errorText={error.message}
                 required={required}
                 programStages={[]}
+                validate={validate}
             />
         )
     }
@@ -36,6 +44,7 @@ export const FieldProgramStageWithAutoLoad = ({ required, programId }) => {
                 disabled
                 required={required}
                 programStages={[]}
+                validate={validate}
             />
         )
     }

--- a/src/smsCommand/useCreateSmsCommandMutation.js
+++ b/src/smsCommand/useCreateSmsCommandMutation.js
@@ -45,10 +45,7 @@ export const CREATE_SMS_COMMAND_MUTATION = {
             }
         }
 
-        if (
-            parserType === TRACKED_ENTITY_REGISTRATION_PARSER.value ||
-            parserType === EVENT_REGISTRATION_PARSER.value
-        ) {
+        if (parserType === TRACKED_ENTITY_REGISTRATION_PARSER.value) {
             return {
                 parserType,
                 name,
@@ -56,7 +53,10 @@ export const CREATE_SMS_COMMAND_MUTATION = {
             }
         }
 
-        if (parserType === PROGRAM_STAGE_DATAENTRY_PARSER.value) {
+        if (
+            parserType === PROGRAM_STAGE_DATAENTRY_PARSER.value ||
+            parserType === EVENT_REGISTRATION_PARSER.value
+        ) {
             return {
                 parserType,
                 name,

--- a/src/smsCommandFields/FieldCommandParser.js
+++ b/src/smsCommandFields/FieldCommandParser.js
@@ -1,3 +1,4 @@
+import { hasValue } from '@dhis2/ui'
 import { PropTypes } from '@dhis2/prop-types'
 import { SingleSelectFieldFF, ReactFinalForm } from '@dhis2/ui'
 import React from 'react'
@@ -20,12 +21,14 @@ const options = Object.values(commandTypes).sort((a, b) => {
 
 export const FieldCommandParser = ({ disabled }) => (
     <Field
+        required
         disabled={disabled}
         dataTest={dataTest('forms-fieldcommandparser')}
         name={FIELD_COMMAND_PARSER_NAME}
         label={i18n.t('Parser')}
         component={SingleSelectFieldFF}
         options={options}
+        validate={hasValue}
     />
 )
 

--- a/src/userGroup/FieldUserGroupWithAutoLoad.js
+++ b/src/userGroup/FieldUserGroupWithAutoLoad.js
@@ -1,3 +1,4 @@
+import { hasValue } from '@dhis2/ui'
 import { PropTypes } from '@dhis2/prop-types'
 import React from 'react'
 
@@ -6,6 +7,7 @@ import { useReadUserGroupsQuery } from './useReadUserGroupsQuery'
 
 export const FieldUserGroupWithAutoLoad = ({ required }) => {
     const { loading, error, data } = useReadUserGroupsQuery()
+    const validate = required ? hasValue : undefined
 
     if (loading) {
         return (
@@ -14,6 +16,7 @@ export const FieldUserGroupWithAutoLoad = ({ required }) => {
                 loading
                 showLoadingStatus
                 userGroups={[]}
+                validate={validate}
             />
         )
     }
@@ -25,6 +28,7 @@ export const FieldUserGroupWithAutoLoad = ({ required }) => {
                 disabled
                 userGroups={[]}
                 errorText={error.message}
+                validate={validate}
             />
         )
     }
@@ -35,7 +39,13 @@ export const FieldUserGroupWithAutoLoad = ({ required }) => {
         value: id,
     }))
 
-    return <FieldUserGroup required={required} userGroups={options} />
+    return (
+        <FieldUserGroup
+            required={required}
+            userGroups={options}
+            validate={validate}
+        />
+    )
 }
 
 FieldUserGroupWithAutoLoad.defaultProps = {

--- a/src/views/sms_commands/SmsCommandFormNew.js
+++ b/src/views/sms_commands/SmsCommandFormNew.js
@@ -118,25 +118,29 @@ const ActualForm = ({ handleSubmit, submitting }) => {
 
                 {showDataSetField && (
                     <FormRow>
-                        <FieldDataSetWithAutoLoad />
+                        <FieldDataSetWithAutoLoad required />
                     </FormRow>
                 )}
 
                 {showUserGroupField && (
                     <FormRow>
-                        <FieldUserGroupWithAutoLoad />
+                        <FieldUserGroupWithAutoLoad required />
                     </FormRow>
                 )}
 
                 {showProgramField && (
                     <FormRow>
-                        <FieldProgramWithAutoLoad registration={registration} />
+                        <FieldProgramWithAutoLoad
+                            required
+                            registration={registration}
+                        />
                     </FormRow>
                 )}
 
                 {showProgramStageField && (
                     <FormRow>
                         <FieldProgramStageWithAutoLoad
+                            required
                             programId={program?.id || ''}
                         />
                     </FormRow>

--- a/src/views/sms_commands/SmsCommandFormNew.js
+++ b/src/views/sms_commands/SmsCommandFormNew.js
@@ -97,6 +97,7 @@ const ActualForm = ({ handleSubmit, submitting }) => {
         parserType === EVENT_REGISTRATION_PARSER.value
 
     const showProgramStageField =
+        parserType === EVENT_REGISTRATION_PARSER.value ||
         parserType === PROGRAM_STAGE_DATAENTRY_PARSER.value
 
     const registration =
@@ -136,7 +137,7 @@ const ActualForm = ({ handleSubmit, submitting }) => {
                 {showProgramStageField && (
                     <FormRow>
                         <FieldProgramStageWithAutoLoad
-                            programId={program || ''}
+                            programId={program?.id || ''}
                         />
                     </FormRow>
                 )}


### PR DESCRIPTION
Fixed DHIS2-9478

- Adds the program stage field to the sms commands when "Event registration parser" is chosen.
- Sends the program stage to the `smsCommands` endpoint when "Event registration parser" is chosen
- Makes all fields required when adding a new sms command