### PR TITLE
fix(new sms cmd form): use correct value for program registration

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-09-07T13:25:20.599Z\n"
-"PO-Revision-Date: 2020-09-07T13:25:20.599Z\n"
+"POT-Creation-Date: 2020-09-16T13:26:09.507Z\n"
+"PO-Revision-Date: 2020-09-16T13:26:09.507Z\n"
 
 msgid "Are you sure you want to cancel? Unsaved changes will be lost"
 msgstr ""
@@ -442,6 +442,9 @@ msgid "Could not find the requested parser type"
 msgstr ""
 
 msgid "Add command"
+msgstr ""
+
+msgid "Automatically selected by selecting a program"
 msgstr ""
 
 msgid "Commands"

--- a/src/program/FieldProgramWithAutoLoad.js
+++ b/src/program/FieldProgramWithAutoLoad.js
@@ -1,14 +1,24 @@
-import { hasValue } from '@dhis2/ui'
+import { hasValue, ReactFinalForm } from '@dhis2/ui'
 import { PropTypes } from '@dhis2/prop-types'
-import React from 'react'
+import React, { useEffect } from 'react'
 
-import { FieldProgram } from './FieldProgram'
-import { useReadProgramsQuery } from './useReadProgramsQuery'
+import { FIELD_PROGRAM_NAME, FieldProgram } from './FieldProgram'
+import { ALL_PROGRAMS, useReadProgramsQuery } from './useReadProgramsQuery'
+
+const { useForm } = ReactFinalForm
 
 export const FieldProgramWithAutoLoad = ({ required, registration }) => {
-    const variables = { registration }
-    const { loading, error, data } = useReadProgramsQuery({ variables })
+    const form = useForm()
     const validate = required ? hasValue : undefined
+    const { loading, error, data, refetch } = useReadProgramsQuery({
+        lazy: true,
+    })
+
+    useEffect(() => {
+        const variables = { registration }
+        form.change(FIELD_PROGRAM_NAME, null)
+        refetch(variables)
+    }, [registration])
 
     if (loading) {
         return (
@@ -51,12 +61,10 @@ export const FieldProgramWithAutoLoad = ({ required, registration }) => {
 
 FieldProgramWithAutoLoad.defaultProps = {
     required: false,
-
-    // undefined = both
-    registration: undefined,
+    registration: ALL_PROGRAMS,
 }
 
 FieldProgramWithAutoLoad.propTypes = {
-    registration: PropTypes.bool,
+    registration: PropTypes.string,
     required: PropTypes.bool,
 }

--- a/src/program/useReadProgramsQuery.js
+++ b/src/program/useReadProgramsQuery.js
@@ -1,17 +1,19 @@
 import { useDataQuery } from '@dhis2/app-runtime'
 
+export const PROGRAMS_WITH_REGISTRATION = 'PROGRAMS_WITH_REGISTRATION'
+export const PROGRAMS_WITHOUT_REGISTRATION = 'PROGRAMS_WITHOUT_REGISTRATION'
+export const ALL_PROGRAMS = 'ALL_PROGRAMS'
+
 export const PROGRAMS_QUERY = {
     programs: {
         resource: 'programs',
         params: ({ registration }) => {
             const params = { paging: 'false' }
 
-            if (typeof registration !== 'undefined') {
-                const filter = registration
-                    ? 'programType:eq:WITH_REGISTRATION'
-                    : 'programType:eq:WITHOUT_REGISTRATION'
-
-                params.filter = filter
+            if (registration === PROGRAMS_WITH_REGISTRATION) {
+                params.filter = 'programType:eq:WITH_REGISTRATION'
+            } else if (registration === PROGRAMS_WITHOUT_REGISTRATION) {
+                params.filter = 'programType:eq:WITHOUT_REGISTRATION'
             }
 
             return params

--- a/src/programStage/FieldProgramStage.js
+++ b/src/programStage/FieldProgramStage.js
@@ -13,23 +13,25 @@ export const FieldProgramStage = ({
     programStages,
     disabled,
     loading,
+    initialValue,
     required,
     errorText,
 }) => (
     <Field
+        component={SingleSelectFieldFF}
+        dataTest={dataTest('forms-fieldprogramStage')}
         disabled={disabled}
         error={!!errorText}
-        validationText={errorText}
-        required={required}
-        loading={loading}
-        dataTest={dataTest('forms-fieldprogramStage')}
-        name={FIELD_PROGRAM_STAGE_NAME}
-        label={i18n.t('Program stage')}
-        component={SingleSelectFieldFF}
-        options={programStages}
-        validate={required && hasValue}
         format={value => value?.id || null}
+        iinitialValue={initialValue}
+        label={i18n.t('Program stage')}
+        loading={loading}
+        name={FIELD_PROGRAM_STAGE_NAME}
+        options={programStages}
         parse={id => ({ id })}
+        required={required}
+        validate={required && hasValue}
+        validationText={errorText}
     />
 )
 
@@ -49,6 +51,7 @@ FieldProgramStage.propTypes = {
     ).isRequired,
     disabled: PropTypes.bool,
     errorText: PropTypes.string,
+    initialValue: PropTypes.string,
     loading: PropTypes.bool,
     required: PropTypes.bool,
 }

--- a/src/programStage/index.js
+++ b/src/programStage/index.js
@@ -1,3 +1,3 @@
 export * from './FieldProgramStage'
-export * from './FieldProgramStageWithAutoLoad'
+export * from './FieldProgramStageWithLoadingStates'
 export * from './useReadProgramStagesQuery'


### PR DESCRIPTION
* [x] Loads the program stages already when loading the program
* [x] Loads the appropriate programs depending on the parser type
* [x] Fix issue with program stage select (see below; see @ismay's [comment](https://github.com/dhis2/sms-configuration-app/pull/64#issuecomment-693300492))

**Program stage select issue**
When selecting the `Program stage data entry parser` or `Tracked entity registration parser` first, everything behaves as it should. When selecting the `Event registration parser` and select both a program and a program stage, after changing to another parser type that uses programs & program stages (currently only `Program stage data entry parser), the program stage select's dropdown doesn't use the full width of the select anymore.