### PR TITLE
fix(received sms): check userCredentials exitence instead of its parent

### DIFF
--- a/src/views/received_sms_list/SmsTable.js
+++ b/src/views/received_sms_list/SmsTable.js
@@ -76,9 +76,8 @@ const SmsTable = ({ messages, pager, selectedIds, setSelectedIds }) => {
                             </TableCell>
                             <TableCell>{message.smsstatus}</TableCell>
                             <TableCell>
-                                {message.user
-                                    ? message.user.userCredentials.username
-                                    : i18n.t('Unknown')}
+                                {message.user?.userCredentials?.username ||
+                                    i18n.t('Unknown')}
                             </TableCell>
                             <TableCell>
                                 <Date date={message.receiveddate} />


### PR DESCRIPTION
Checks for existence of `user.userCredentials` instead of just `user` on the individual `message` objects.
Haven't changed any translations, must be leftovers from a previous change