### PR TITLE
fix: remove explanatory text

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-09-22T12:51:22.166Z\n"
-"PO-Revision-Date: 2020-09-22T12:51:22.166Z\n"
+"POT-Creation-Date: 2020-09-22T13:59:54.870Z\n"
+"PO-Revision-Date: 2020-09-22T13:59:54.870Z\n"
 
 msgid "Are you sure you want to cancel? Unsaved changes will be lost"
 msgstr ""
@@ -57,11 +57,6 @@ msgid "Gateway setup"
 msgstr ""
 
 msgid "Key value pairs"
-msgstr ""
-
-msgid ""
-"Key value pairs can be included in the URL. This is some helper text which "
-"provides an intro to what the key value pairs actually do."
 msgstr ""
 
 msgid "Key"

--- a/src/gateways/GatewayGenericForm.js
+++ b/src/gateways/GatewayGenericForm.js
@@ -10,7 +10,6 @@ import {
 } from '../gateways'
 import { FormRow } from '../forms'
 import { PageSubHeadline } from '../headline'
-import { Paragraph } from '../text'
 import { dataTest } from '../dataTest'
 import i18n from '../locales'
 
@@ -49,12 +48,6 @@ export const GatewayGenericForm = ({
                     <PageSubHeadline>
                         {i18n.t('Key value pairs')}
                     </PageSubHeadline>
-
-                    <Paragraph>
-                        {i18n.t(
-                            'Key value pairs can be included in the URL. This is some helper text which provides an intro to what the key value pairs actually do.'
-                        )}
-                    </Paragraph>
 
                     {values.parameters.map((_, index) => (
                         <GatewayKeyValuePair index={index} key={index} />


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-9583

Since the [docs](https://docs.dhis2.org/master/en/dhis2_developer_manual/web-api.html#generic-http) are not clear (to me) about what the key value pairs do precisely, I've removed the text for now.