### PR TITLE
fix(key-value-pair): fix editing and validating confidential fields

### DIFF
--- a/src/gateways/GatewayGenericForm.js
+++ b/src/gateways/GatewayGenericForm.js
@@ -56,8 +56,16 @@ export const GatewayGenericForm = ({
                         )}
                     </Paragraph>
 
-                    {values.parameters.map((_, index) => (
-                        <GatewayKeyValuePair index={index} key={index} />
+                    {values.parameters.map((param, index) => (
+                        <GatewayKeyValuePair
+                            index={index}
+                            key={index}
+                            isExistingConfidentialKey={initialValues.parameters.some(
+                                initialParam =>
+                                    initialParam.confidential &&
+                                    initialParam.key === param.key
+                            )}
+                        />
                     ))}
 
                     <GatewayAddKeyValuePair />

--- a/src/gateways/GatewayKeyValuePair.js
+++ b/src/gateways/GatewayKeyValuePair.js
@@ -17,7 +17,7 @@ import styles from './GatewayKeyValuePair.module.css'
 const { Field, useForm } = ReactFinalForm
 const isStringWithLengthAtLeastOne = composeValidators(string, hasValue)
 
-export const GatewayKeyValuePair = ({ index }) => {
+export const GatewayKeyValuePair = ({ index, isExistingConfidentialKey }) => {
     const { change, getState } = useForm()
 
     const removeKeyValueFromFormState = index => {
@@ -54,7 +54,23 @@ export const GatewayKeyValuePair = ({ index }) => {
                     name={`parameters[${index}].value`}
                     label={i18n.t('Value')}
                     component={InputFieldFF}
-                    validate={isStringWithLengthAtLeastOne}
+                    validate={
+                        isExistingConfidentialKey
+                            ? string
+                            : isStringWithLengthAtLeastOne
+                    }
+                    placeholder={
+                        isExistingConfidentialKey
+                            ? i18n.t('Confidential')
+                            : undefined
+                    }
+                    helpText={
+                        isExistingConfidentialKey
+                            ? i18n.t(
+                                  'Current value is not displayed, but you can set a new one'
+                              )
+                            : undefined
+                    }
                 />
             </div>
 
@@ -105,4 +121,5 @@ export const GatewayKeyValuePair = ({ index }) => {
 
 GatewayKeyValuePair.propTypes = {
     index: PropTypes.number.isRequired,
+    isExistingConfidentialKey: PropTypes.bool.isRequired,
 }


### PR DESCRIPTION
First an explanation of the problem:
- If a key-value parameter is confidential, no value is returned from GET requests to the server as a security measure
- That has some consequences:
    - When a new key-value parameter is being added to a new or existing sms-gateway, the field can be treated as mandatory, as we were already doing
    - When the user is editing a sms-gateway and wants to keep the current value of the confidential key-value parameter, we should allow sending an empty value so the field should be treated as optional. This was going wrong, because we were still treating the field as mandatory.

Then the solution I implemented:
- If a confidential key-value parameter with an existing key is being edited the field validation will switch from mandatory to optional
- And I will show a placeholder text saying "Confidential"
- Plus a help text saying "Current value is not displayed, but you can set a new one"

The solution in this PR makes two assumptions, which I would like to check with @zubaira:
1. If the server receives a PUT with an array of key-value parameters, in principle all the existing parameters are replaced by the new ones
2. One notable exception are the confidential parameters, if a confidential parameter with an existing key and an empty value is encountered in the payload, the value will be populated by the value that is already present in the database

If one of these assumptions is incorrect we should not merge this PR because the current solution will probably cause issues.

If the first assumption is not correct, then I think we should consider making the `key` field a fixed field: it can be defined when creating a key-value parameter, but never changed.