### PR TITLE
feat(credential keyvalue pair): change credential field to type password

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-09-23T12:12:54.689Z\n"
-"PO-Revision-Date: 2020-09-23T12:12:54.689Z\n"
+"POT-Creation-Date: 2020-09-24T12:57:20.633Z\n"
+"PO-Revision-Date: 2020-09-24T12:57:20.633Z\n"
 
 msgid "Are you sure you want to cancel? Unsaved changes will be lost"
 msgstr ""
@@ -18,6 +18,11 @@ msgid "Yes, cancel"
 msgstr ""
 
 msgid "Dataset"
+msgstr ""
+
+msgid ""
+"Please make sure the value of this input matches the value in "
+"\"{{otherField}}\"."
 msgstr ""
 
 msgid "Confirm deletion"
@@ -65,9 +70,6 @@ msgstr ""
 msgid "Key"
 msgstr ""
 
-msgid "Value"
-msgstr ""
-
 msgid "Send as header"
 msgstr ""
 
@@ -78,6 +80,12 @@ msgid "Confidential"
 msgstr ""
 
 msgid "Remove key value pair"
+msgstr ""
+
+msgid "Confirm confidential value"
+msgstr ""
+
+msgid "Value"
 msgstr ""
 
 msgid "Type"

--- a/src/forms/createEqualTo.js
+++ b/src/forms/createEqualTo.js
@@ -1,0 +1,52 @@
+import i18n from '@dhis2/d2-i18n'
+
+const isEmpty = value =>
+    typeof value === 'undefined' || value === null || value === ''
+
+export const requiredArgumentErrorMessage =
+    'Incorrect arguments provided when creating validator'
+
+export const requireArgument = (value, type) => {
+    if (isEmpty(value) || typeof value !== type) {
+        throw new Error(requiredArgumentErrorMessage)
+    }
+}
+
+const arrayIndexRegex = /\[(\d+)\]$/
+const delimiter = '.'
+const getByPath = (path, object) => {
+    const segments = path.split(delimiter)
+    const value = segments.reduce((curValue, segment) => {
+        if (!curValue) return curValue
+
+        if (segment.match(arrayIndexRegex)) {
+            const arraySegment = segment.replace(arrayIndexRegex, '')
+            const arrayIndex = parseInt(segment.match(arrayIndexRegex)[1], 10)
+
+            if (!curValue[arraySegment]) return curValue[arraySegment]
+            return curValue[arraySegment][arrayIndex]
+        }
+
+        const segmentValue = curValue[segment]
+        if (!segmentValue) return null
+        return segmentValue
+    }, object)
+
+    return value
+}
+
+export const createEqualTo = (key, description) => {
+    requireArgument(key, 'string')
+
+    const errorMessage = i18n.t(
+        'Please make sure the value of this input matches the value in "{{otherField}}".',
+        { otherField: description || key }
+    )
+
+    return (value, allValues) => {
+        const comparisonValue = getByPath(key, allValues)
+        return isEmpty(value) || value === comparisonValue
+            ? undefined
+            : errorMessage
+    }
+}

--- a/src/forms/index.js
+++ b/src/forms/index.js
@@ -1,1 +1,2 @@
 export * from './FormRow'
+export * from './createEqualTo'

--- a/src/gateways/GatewayKeyValuePair.js
+++ b/src/gateways/GatewayKeyValuePair.js
@@ -10,6 +10,7 @@ import {
 import React from 'react'
 import { PropTypes } from '@dhis2/prop-types'
 
+import { GatewayKeyValuePairValue } from './GatewayKeyValuePairValue'
 import { dataTest } from '../dataTest'
 import i18n from '../locales'
 import styles from './GatewayKeyValuePair.module.css'
@@ -48,14 +49,9 @@ export const GatewayKeyValuePair = ({ index }) => {
                     validate={isStringWithLengthAtLeastOne}
                 />
 
-                <Field
-                    dataTest={dataTest('gateways-gatewaykeyvaluepair-value')}
-                    className={styles.valueInput}
-                    name={`parameters[${index}].value`}
-                    label={i18n.t('Value')}
-                    component={InputFieldFF}
-                    validate={isStringWithLengthAtLeastOne}
-                />
+                <div className={styles.valueInput}>
+                    <GatewayKeyValuePairValue index={index} />
+                </div>
             </div>
 
             <div className={styles.checkboxGroup}>

--- a/src/gateways/GatewayKeyValuePair.module.css
+++ b/src/gateways/GatewayKeyValuePair.module.css
@@ -12,9 +12,9 @@
     margin-bottom: 16px;
 }
 
-.keyInput,
-.valueInput {
+.keyInput, .valueInput {
     flex-grow: 1;
+    width: calc(50% - var(--spacers-dp4));
 }
 
 .keyInput {

--- a/src/gateways/GatewayKeyValuePairConfidentialValueFields.js
+++ b/src/gateways/GatewayKeyValuePairConfidentialValueFields.js
@@ -1,0 +1,59 @@
+import {
+    InputFieldFF,
+    ReactFinalForm,
+    composeValidators,
+    string,
+    hasValue,
+} from '@dhis2/ui'
+import { PropTypes } from '@dhis2/prop-types'
+import React from 'react'
+
+import {
+    FIELD_GATEWAY_KEY_VALUE_PAIR_VALUE_LABEL,
+    GatewayKeyValuePairValueField,
+    createFieldGatewayKeyValuePairValueName,
+} from './GatewayKeyValuePairValueField'
+import { FormRow, createEqualTo } from '../forms'
+import { dataTest } from '../dataTest'
+import i18n from '../locales'
+
+const { Field } = ReactFinalForm
+
+const createEqualToConfidentialValue = index =>
+    createEqualTo(
+        createFieldGatewayKeyValuePairValueName(index),
+        FIELD_GATEWAY_KEY_VALUE_PAIR_VALUE_LABEL
+    )
+
+export const FIELD_GATEWAY_KEY_VALUE_PAIR_VALUE_CONFIRMATION_LABEL = i18n.t(
+    'Confirm confidential value'
+)
+
+export const GatewayKeyValuePairConfidentialValueFields = ({ index }) => {
+    return (
+        <>
+            <FormRow>
+                <GatewayKeyValuePairValueField isConfidential index={index} />
+            </FormRow>
+
+            <Field
+                dataTest={dataTest(
+                    'gateways-gatewaykeyvaluepair-valueconfirmation'
+                )}
+                type="password"
+                name={`confirmation[${index}]`}
+                label={FIELD_GATEWAY_KEY_VALUE_PAIR_VALUE_CONFIRMATION_LABEL}
+                component={InputFieldFF}
+                validate={composeValidators(
+                    string,
+                    hasValue,
+                    createEqualToConfidentialValue(index)
+                )}
+            />
+        </>
+    )
+}
+
+GatewayKeyValuePairConfidentialValueFields.propTypes = {
+    index: PropTypes.number.isRequired,
+}

--- a/src/gateways/GatewayKeyValuePairConfidentialValueFields.module.css
+++ b/src/gateways/GatewayKeyValuePairConfidentialValueFields.module.css
@@ -1,0 +1,3 @@
+.valueInput {
+    flex-grow: 1;
+}

--- a/src/gateways/GatewayKeyValuePairValue.js
+++ b/src/gateways/GatewayKeyValuePairValue.js
@@ -1,0 +1,23 @@
+import { ReactFinalForm } from '@dhis2/ui'
+import { PropTypes } from '@dhis2/prop-types'
+import React from 'react'
+
+import { GatewayKeyValuePairValueField } from './GatewayKeyValuePairValueField'
+import { GatewayKeyValuePairConfidentialValueFields } from './GatewayKeyValuePairConfidentialValueFields'
+
+const { useField } = ReactFinalForm
+
+export const GatewayKeyValuePairValue = ({ index }) => {
+    const { input } = useField(`parameters[${index}]`)
+    const { confidential } = input.value
+
+    if (confidential) {
+        return <GatewayKeyValuePairConfidentialValueFields index={index} />
+    }
+
+    return <GatewayKeyValuePairValueField index={index} />
+}
+
+GatewayKeyValuePairValue.propTypes = {
+    index: PropTypes.number.isRequired,
+}

--- a/src/gateways/GatewayKeyValuePairValueField.js
+++ b/src/gateways/GatewayKeyValuePairValueField.js
@@ -1,0 +1,40 @@
+import {
+    InputFieldFF,
+    ReactFinalForm,
+    composeValidators,
+    string,
+    hasValue,
+} from '@dhis2/ui'
+import { PropTypes } from '@dhis2/prop-types'
+import React from 'react'
+
+import { dataTest } from '../dataTest'
+import i18n from '../locales'
+
+const { Field } = ReactFinalForm
+const isStringWithLengthAtLeastOne = composeValidators(string, hasValue)
+
+export const createFieldGatewayKeyValuePairValueName = index =>
+    `parameters[${index}].value`
+
+export const FIELD_GATEWAY_KEY_VALUE_PAIR_VALUE_LABEL = i18n.t('Value')
+
+export const GatewayKeyValuePairValueField = ({ index, isConfidential }) => (
+    <Field
+        type={isConfidential ? 'password' : 'text'}
+        dataTest={dataTest('gateways-gatewaykeyvaluepair-value')}
+        name={createFieldGatewayKeyValuePairValueName(index)}
+        label={FIELD_GATEWAY_KEY_VALUE_PAIR_VALUE_LABEL}
+        component={InputFieldFF}
+        validate={isStringWithLengthAtLeastOne}
+    />
+)
+
+GatewayKeyValuePairValueField.defaultProps = {
+    isConfidential: false,
+}
+
+GatewayKeyValuePairValueField.propTypes = {
+    index: PropTypes.number.isRequired,
+    isConfidential: PropTypes.bool,
+}


### PR DESCRIPTION
This will make sure that credential fields of key value pairs are of type password and adds a confirmation field.
I had to copy the `createEqualTo` form validator's code as it doesn't resolve paths, just play keys, while final form can handles paths. I'll create a UI issue for that, we could copy the code I've added in this PR to the UI's validator as well.