### PR TITLE
feat(generic gateway): add 4 missing fields to form

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -34,6 +34,27 @@ msgstr ""
 msgid "Auth token"
 msgstr ""
 
+msgid "Configuration template"
+msgstr ""
+
+msgid "Please refer to the documentation for possible values"
+msgstr ""
+
+msgid "Application/json"
+msgstr ""
+
+msgid "Application/xml"
+msgstr ""
+
+msgid "Form url encoded"
+msgstr ""
+
+msgid "Plain text"
+msgstr ""
+
+msgid "Content type"
+msgstr ""
+
 msgid "Name"
 msgstr ""
 
@@ -43,7 +64,16 @@ msgstr ""
 msgid "Confirm password"
 msgstr ""
 
+msgid "Send url parameters"
+msgstr ""
+
 msgid "Url template"
+msgstr ""
+
+msgid "Use GET"
+msgstr ""
+
+msgid "Not using get results in using POST"
 msgstr ""
 
 msgid "User name"

--- a/src/gateways/FieldGatewayConfigurationTemplate.js
+++ b/src/gateways/FieldGatewayConfigurationTemplate.js
@@ -1,0 +1,26 @@
+import {
+    InputFieldFF,
+    ReactFinalForm,
+    composeValidators,
+    hasValue,
+    string,
+} from '@dhis2/ui'
+import React from 'react'
+import { dataTest } from '../dataTest'
+import i18n from '../locales'
+
+const { Field } = ReactFinalForm
+
+export const FieldGatewayConfigurationTemplate = () => (
+    <Field
+        required
+        dataTest={dataTest('gateways-fieldgatewayconfigurationtemplate')}
+        name="configurationTemplate"
+        label={i18n.t('Configuration template')}
+        component={InputFieldFF}
+        validate={composeValidators(string, hasValue)}
+        helpText={i18n.t(
+            'Please refer to the documentation for possible values'
+        )}
+    />
+)

--- a/src/gateways/FieldGatewayContentType.js
+++ b/src/gateways/FieldGatewayContentType.js
@@ -1,0 +1,44 @@
+import { SingleSelectFieldFF, ReactFinalForm } from '@dhis2/ui'
+import React from 'react'
+import { dataTest } from '../dataTest'
+import i18n from '../locales'
+
+const { Field } = ReactFinalForm
+
+const optionApplicationJson = {
+    label: i18n.t('Application/json'),
+    value: 'APPLICATION_JSON',
+}
+
+const optionApplicationXml = {
+    label: i18n.t('Application/xml'),
+    value: 'APPLICATION_XML',
+}
+
+const optionFormUrlEncoded = {
+    label: i18n.t('Form url encoded'),
+    value: 'FORM_URL_ENCODED',
+}
+
+const optionTextPlain = {
+    label: i18n.t('Plain text'),
+    value: 'TEXT_PLAIN',
+}
+
+const options = [
+    optionApplicationJson,
+    optionApplicationXml,
+    optionFormUrlEncoded,
+    optionTextPlain,
+]
+
+export const FieldGatewayContentType = () => (
+    <Field
+        dataTest={dataTest('gateways-fieldgatewaycontenttype')}
+        name="contentType"
+        label={i18n.t('Content type')}
+        component={SingleSelectFieldFF}
+        options={options}
+        initialValue={optionApplicationJson.value}
+    />
+)

--- a/src/gateways/FieldGatewaySendUrlParameters.js
+++ b/src/gateways/FieldGatewaySendUrlParameters.js
@@ -1,0 +1,16 @@
+import { CheckboxFieldFF, ReactFinalForm } from '@dhis2/ui'
+import React from 'react'
+import { dataTest } from '../dataTest'
+import i18n from '../locales'
+
+const { Field } = ReactFinalForm
+
+export const FieldGatewaySendUrlParameters = () => (
+    <Field
+        type="checkbox"
+        dataTest={dataTest('gateways-fieldgatewaysendurlparameters')}
+        name="sendUrlParameters"
+        label={i18n.t('Send url parameters')}
+        component={CheckboxFieldFF}
+    />
+)

--- a/src/gateways/FieldGatewayUseGet.js
+++ b/src/gateways/FieldGatewayUseGet.js
@@ -1,0 +1,17 @@
+import { CheckboxFieldFF, ReactFinalForm } from '@dhis2/ui'
+import React from 'react'
+import { dataTest } from '../dataTest'
+import i18n from '../locales'
+
+const { Field } = ReactFinalForm
+
+export const FieldGatewayUseGet = () => (
+    <Field
+        type="checkbox"
+        dataTest={dataTest('gateways-fieldgatewayuseget')}
+        name="useGet"
+        label={i18n.t('Use GET')}
+        component={CheckboxFieldFF}
+        helpText={i18n.t('Not using get results in using POST')}
+    />
+)

--- a/src/gateways/FieldGatewayUseGet.js
+++ b/src/gateways/FieldGatewayUseGet.js
@@ -12,6 +12,6 @@ export const FieldGatewayUseGet = () => (
         name="useGet"
         label={i18n.t('Use GET')}
         component={CheckboxFieldFF}
-        helpText={i18n.t('Not using get results in using POST')}
+        helpText={i18n.t('Use GET instead of POST to send data to gateway')}
     />
 )

--- a/src/gateways/GatewayGenericForm.js
+++ b/src/gateways/GatewayGenericForm.js
@@ -8,6 +8,10 @@ import {
     GatewayAddKeyValuePair,
     GatewayKeyValuePair,
 } from '../gateways'
+import { FieldGatewayConfigurationTemplate } from './FieldGatewayConfigurationTemplate'
+import { FieldGatewayUseGet } from './FieldGatewayUseGet'
+import { FieldGatewaySendUrlParameters } from './FieldGatewaySendUrlParameters'
+import { FieldGatewayContentType } from './FieldGatewayContentType'
 import { FormRow } from '../forms'
 import { PageSubHeadline } from '../headline'
 import { dataTest } from '../dataTest'
@@ -43,6 +47,22 @@ export const GatewayGenericForm = ({
 
                     <FormRow>
                         <FieldGatewayUrlTemplate />
+                    </FormRow>
+
+                    <FormRow>
+                        <FieldGatewayConfigurationTemplate />
+                    </FormRow>
+
+                    <FormRow>
+                        <FieldGatewayContentType />
+                    </FormRow>
+
+                    <FormRow>
+                        <FieldGatewayUseGet />
+                    </FormRow>
+
+                    <FormRow>
+                        <FieldGatewaySendUrlParameters />
                     </FormRow>
 
                     <PageSubHeadline>

--- a/src/gateways/createGenericGateWayDataFromVariables.js
+++ b/src/gateways/createGenericGateWayDataFromVariables.js
@@ -1,0 +1,42 @@
+/**
+ * This the shape of the additional fields
+ * that can be added to a generic config
+ *
+ * @typedef {Object} Parameter
+ * @prop {string} key
+ * @prop {string} value
+ * @prop {bool} header
+ * @prop {bool} encode
+ * @prop {bool} confidential
+ */
+
+/**
+ * @param {Object} args
+ * @param {string} args.configurationTemplate
+ * @param {string} args.contentType
+ * @param {string} args.name
+ * @param {string} args.urlTemplate
+ * @param {bool} args.sendUrlParameters
+ * @param {bool} args.useGet
+ * @param {Parameter[]} args.parameters
+ *
+ * @returns {Object}
+ */
+export const createGenericGateWayDataFromVariables = ({
+    configurationTemplate,
+    contentType,
+    name,
+    parameters,
+    sendUrlParameters,
+    urlTemplate,
+    useGet,
+}) => ({
+    type: 'http',
+    configurationTemplate,
+    contentType,
+    name,
+    parameters,
+    sendUrlParameters,
+    urlTemplate,
+    useGet,
+})

--- a/src/gateways/useCreateGenericGatewayMutation.js
+++ b/src/gateways/useCreateGenericGatewayMutation.js
@@ -1,52 +1,10 @@
 import { useDataMutation } from '@dhis2/app-runtime'
-
-/**
- * This the shape of the additional fields
- * that can be added to a generic config
- *
- * @typedef {Object} Parameter
- * @prop {string} key
- * @prop {string} value
- * @prop {bool} header
- * @prop {bool} encode
- * @prop {bool} confidential
- */
-
-/**
- * @param {Object} args
- * @param {string} args.configurationTemplate
- * @param {string} args.contentType
- * @param {string} args.name
- * @param {string} args.urlTemplate
- * @param {bool} args.sendUrlParameters
- * @param {bool} args.useGet
- * @param {Parameter[]} args.parameters
- *
- * @returns {Object}
- */
-const createDataFromVariables = ({
-    configurationTemplate,
-    contentType,
-    name,
-    parameters,
-    sendUrlParameters,
-    urlTemplate,
-    useGet,
-}) => ({
-    type: 'http',
-    configurationTemplate,
-    contentType,
-    name,
-    parameters,
-    sendUrlParameters,
-    urlTemplate,
-    useGet,
-})
+import { createGenericGateWayDataFromVariables } from './createGenericGateWayDataFromVariables'
 
 export const CREATE_GENERIC_GATEWAY_MUTATION = {
     resource: 'gateways',
     type: 'create',
-    data: createDataFromVariables,
+    data: createGenericGateWayDataFromVariables,
 }
 
 export const useCreateGenericGatewayMutation = () =>

--- a/src/gateways/useCreateGenericGatewayMutation.js
+++ b/src/gateways/useCreateGenericGatewayMutation.js
@@ -14,17 +14,33 @@ import { useDataMutation } from '@dhis2/app-runtime'
 
 /**
  * @param {Object} args
+ * @param {string} args.configurationTemplate
+ * @param {string} args.contentType
  * @param {string} args.name
  * @param {string} args.urlTemplate
+ * @param {bool} args.sendUrlParameters
+ * @param {bool} args.useGet
  * @param {Parameter[]} args.parameters
  *
  * @returns {Object}
  */
-const createDataFromVariables = ({ name, urlTemplate, parameters }) => ({
-    type: 'http',
+const createDataFromVariables = ({
+    configurationTemplate,
+    contentType,
     name,
-    urlTemplate,
     parameters,
+    sendUrlParameters,
+    urlTemplate,
+    useGet,
+}) => ({
+    type: 'http',
+    configurationTemplate,
+    contentType,
+    name,
+    parameters,
+    sendUrlParameters,
+    urlTemplate,
+    useGet,
 })
 
 export const CREATE_GENERIC_GATEWAY_MUTATION = {

--- a/src/gateways/useUpdateGenericGatewayMutation.js
+++ b/src/gateways/useUpdateGenericGatewayMutation.js
@@ -1,37 +1,11 @@
 import { useUpdateGatewayMutation } from './useUpdateGatewayMutation'
-
-/**
- * This the shape of the additional fields
- * that can be added to a generic config
- *
- * @typedef {Object} Parameter
- * @prop {string} key
- * @prop {string} value
- * @prop {bool} header
- * @prop {bool} encode
- * @prop {bool} confidential
- */
-
-/**
- * @param {Object} args
- * @param {string} args.name
- * @param {string} args.urlTemplate
- * @param {Parameter[]} args.parameters
- *
- * @returns {Object}
- */
-const updateDataFromVariables = ({ name, urlTemplate, parameters }) => ({
-    type: 'http',
-    name,
-    urlTemplate,
-    parameters,
-})
+import { createGenericGateWayDataFromVariables } from './createGenericGateWayDataFromVariables'
 
 export const UPDATE_GENERIC_GATEWAY_MUTATION = {
     resource: 'gateways',
     id: ({ id }) => id,
     type: 'replace',
-    data: updateDataFromVariables,
+    data: createGenericGateWayDataFromVariables,
 }
 
 export const useUpdateGenericGatewayMutation = () =>


### PR DESCRIPTION
This add 4 new fields to the generic gateway form:

* Configuration template
* Content type
* Use get
* Send url parameters

A proper description can be found in the [api docs](https://docs.dhis2.org/master/en/dhis2_developer_manual/web-api.html#generic-http)