### PR TITLE
fix: make sure each filter param gets prefixed with 'filter='

### DIFF
--- a/src/views/received_sms_list/ReceivedSmsList.js
+++ b/src/views/received_sms_list/ReceivedSmsList.js
@@ -41,10 +41,9 @@ const query = {
             if (status && status !== STATUS_ALL) {
                 filters.push(`smsstatus:eq:${status}`)
             }
-            const filterParams = filters.join('&')
 
-            if (filterParams) {
-                params.filter = filterParams
+            if (filters.length > 0) {
+                params.filter = filters
             }
 
             return params


### PR DESCRIPTION
This was a case of me doing too much work. You can actually pass an array of filters to the data query and that will make sure each filter is prefixed with `filter=` and it will separate them with an `&`. So me joining the filters into a string was a bad idea.