### PR TITLE
fix(short code formula): use dataElement id instead of non-existing code

### DIFF
--- a/src/smsCommandFields/FieldDataElementWithCategoryOptionComboAddFormulaButton.js
+++ b/src/smsCommandFields/FieldDataElementWithCategoryOptionComboAddFormulaButton.js
@@ -10,11 +10,8 @@ const { useField } = ReactFinalForm
 const DATA_ELEMENTS_QUERY = {
     dataElement: {
         resource: 'dataElements',
-        params: ({ code }) => ({
-            filter: `code:eq:${code}`,
-            fields: 'displayName',
-            paging: 'false',
-        }),
+        id: ({ id }) => id,
+        params: () => ({ fields: 'displayName' }),
     },
 }
 
@@ -34,29 +31,29 @@ export const FieldDataElementWithCategoryOptionComboAddFormulaButton = ({
 
     const { formula, code } = smsCode
     const operator = formula && formula[0]
-    const dataElementCode = formula && formula.slice(1)
+    const dataElementId = formula && formula.slice(1)
 
     useEffect(() => {
-        if (!called && dataElementCode) {
+        if (!called && dataElementId) {
             setLoading(true)
             setCalled(true)
 
             engine
                 .query(DATA_ELEMENTS_QUERY, {
-                    variables: { code: dataElementCode },
+                    variables: { id: dataElementId },
                 })
                 .then(response => {
-                    const [{ displayName }] = response.dataElement.dataElements
+                    const { displayName } = response.dataElement
                     setFormulaDataElementName(displayName)
                 })
                 .finally(() => setLoading(false))
         }
-    }, [dataElementCode, called])
+    }, [dataElementId, called])
 
     return (
         <>
             {loading && i18n.t('Loading formula')}
-            {code && formulaDataElementName && (
+            {code && formula && formulaDataElementName && (
                 <span className={styles.formulaInWords}>
                     <span className={styles.formulaInWordsLabel}>
                         {i18n.t('Formula')}:

--- a/src/smsCommandFields/FieldDataElementWithCategoryOptionComboFormula.js
+++ b/src/smsCommandFields/FieldDataElementWithCategoryOptionComboFormula.js
@@ -67,10 +67,10 @@ export const FieldDataElementWithCategoryOptionComboFormula = ({
     }
 
     const options = data.map(dataElement => {
-        const { code, displayName } = dataElement
+        const { id, displayName } = dataElement
 
         return {
-            value: code,
+            value: id,
             label: displayName,
         }
     })


### PR DESCRIPTION
Fixes DHIS2-9905

Fixes the broken formula functionality.
To check:

1. go to sms commands
1. edit a j2me command
1. scroll down to the short codes
1. add a value to a code (to enable the formula button)
1. add, save, modify, remove formula