### PR TITLE
fix(sms commands): show correct formula after update [DHIS2-9932]

### DIFF
--- a/src/smsCommandFields/FieldDataElementWithCategoryOptionComboAddFormulaButton.js
+++ b/src/smsCommandFields/FieldDataElementWithCategoryOptionComboAddFormulaButton.js
@@ -21,7 +21,6 @@ export const FieldDataElementWithCategoryOptionComboAddFormulaButton = ({
     disabled,
 }) => {
     const engine = useDataEngine()
-    const [called, setCalled] = useState(false)
     const [loading, setLoading] = useState(false)
     const [formulaDataElementName, setFormulaDataElementName] = useState('')
 
@@ -34,9 +33,8 @@ export const FieldDataElementWithCategoryOptionComboAddFormulaButton = ({
     const dataElementId = formula && formula.slice(1)
 
     useEffect(() => {
-        if (!called && dataElementId) {
+        if (dataElementId) {
             setLoading(true)
-            setCalled(true)
 
             engine
                 .query(DATA_ELEMENTS_QUERY, {
@@ -48,20 +46,19 @@ export const FieldDataElementWithCategoryOptionComboAddFormulaButton = ({
                 })
                 .finally(() => setLoading(false))
         }
-    }, [dataElementId, called])
+    }, [dataElementId])
 
     return (
         <>
-            {loading && i18n.t('Loading formula')}
             {code && formula && formulaDataElementName && (
                 <span className={styles.formulaInWords}>
                     <span className={styles.formulaInWordsLabel}>
                         {i18n.t('Formula')}:
                     </span>
 
-                    {code}
-                    {` ${operator} `}
-                    {formulaDataElementName}
+                    {loading && i18n.t('Loading formula')}
+                    {!loading &&
+                        `${code} ${operator} ${formulaDataElementName}`}
                 </span>
             )}
 


### PR DESCRIPTION
Currently the component responsible for this only loaded the name of the data element once, which obviously is wrong:
Changing the data element of a formula did not have a visual effect (it has been saved correctly though)

How to reproduce:
1. Go to sms configuration app
1. Go to commands section
1. Create a J2ME command if not existing yet
1. Edit a J2ME command 
1. Add a value to one of the short codes if there is no short code with a value yet
1. Add a formula to a short code with a value if there's no short code with a formula yet
1. Change the data element of the formula
1. Save the changes
1. The newly chosen data element's name is not displayed below the short code's value input field. Instead the old one is still being shown