### PR TITLE
fix(sent sms list): use flex-end instead of end

### DIFF
--- a/src/views/sent_sms_list/SentSmsList.module.css
+++ b/src/views/sent_sms_list/SentSmsList.module.css
@@ -4,7 +4,7 @@
 
 .header {
     display: flex;
-    align-items: end;
+    align-items: flex-end;
     margin-bottom: var(--spacers-dp16);
 }
 


### PR DESCRIPTION
`align-items: flex-end` is better supported than `align-items: end` according to [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items#support_in_flex_layout) and Firefox Dev Tools:

![image](https://user-images.githubusercontent.com/4295266/103902912-184e6d00-50f3-11eb-9f5a-688ba6714323.png)
