### PR TITLE
chore(release): migrate to new app version scheme

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# default code owner for repo
+*        @dhis2/team-platform
+
+# code owners for functionality
+/src/    @dhis2/team-platform @dhis2/team-qa
+/docs/   @dhis2/team-platform @dhis2/team-qa

--- a/d2.config.js
+++ b/d2.config.js
@@ -4,6 +4,8 @@ const config = {
     title: 'SMS Configuration',
     description: 'Configure SMS gateways and manage SMS messages',
     coreApp: true,
+    minDHIS2Version: '2.35',
+    id: '441cad0c-395a-4e93-8f10-475602397371',
 
     entryPoints: {
         app: './src/index.js',


### PR DESCRIPTION
Align all our application versions that range between 0.x.x and 36.x.x
with different semantics to a single version scheme with distinct
semantics for what constitutes a breaking change.

We have chosen to bump to v100.0.0 to signify the depature from the old
version scheme to the new.

For more information:
dhis2/notes#293

BREAKING CHANGE: App version becomes decoupled from DHIS2 versions, see
the d2.config.js or App Hub for DHIS2 version compatibility.
