### PR TITLE
fix(sms key value parser commands): create short code input fields correclty

### DIFF
--- a/src/sms-command/DataElementTimesCategoryOptionCombos/DataElementTimesCategoryOptionCombos.js
+++ b/src/sms-command/DataElementTimesCategoryOptionCombos/DataElementTimesCategoryOptionCombos.js
@@ -50,7 +50,7 @@ DataElementTimesCategoryOptionCombos.propTypes = {
                 id: PropTypes.string.isRequired,
             }).isRequired,
             categoryOptionCombo: PropTypes.shape({
-                code: PropTypes.string.isRequired,
+                // code: PropTypes.string.isRequired,
                 displayName: PropTypes.string.isRequired,
                 id: PropTypes.string.isRequired,
             }),

--- a/src/sms-command/DataElementTimesCategoryOptionCombos/DataElementTimesCategoryOptionCombos.js
+++ b/src/sms-command/DataElementTimesCategoryOptionCombos/DataElementTimesCategoryOptionCombos.js
@@ -50,7 +50,6 @@ DataElementTimesCategoryOptionCombos.propTypes = {
                 id: PropTypes.string.isRequired,
             }).isRequired,
             categoryOptionCombo: PropTypes.shape({
-                // code: PropTypes.string.isRequired,
                 displayName: PropTypes.string.isRequired,
                 id: PropTypes.string.isRequired,
             }),

--- a/src/sms-command/FieldDataElementWithCategoryOptionCombo/FieldDataElementWithCategoryOptionCombo.js
+++ b/src/sms-command/FieldDataElementWithCategoryOptionCombo/FieldDataElementWithCategoryOptionCombo.js
@@ -101,7 +101,6 @@ FieldDataElementWithCategoryOptionCombo.propTypes = {
         id: PropTypes.string.isRequired,
     }).isRequired,
     categoryOptionCombo: PropTypes.shape({
-        // code: PropTypes.string.isRequired,
         displayName: PropTypes.string.isRequired,
         id: PropTypes.string.isRequired,
     }),

--- a/src/sms-command/FieldDataElementWithCategoryOptionCombo/FieldDataElementWithCategoryOptionCombo.js
+++ b/src/sms-command/FieldDataElementWithCategoryOptionCombo/FieldDataElementWithCategoryOptionCombo.js
@@ -10,7 +10,7 @@ import { FormulaModalForm } from './FormulaModalForm.js'
 
 const DE_COC_toFormName = (dataElement, categoryOptionCombo) => {
     const dataElementId = dataElement.id
-    const cocCode = categoryOptionCombo?.code
+    const cocCode = categoryOptionCombo?.id
     const isDefault = cocCode === 'default'
 
     if (!cocCode || isDefault) {
@@ -101,7 +101,7 @@ FieldDataElementWithCategoryOptionCombo.propTypes = {
         id: PropTypes.string.isRequired,
     }).isRequired,
     categoryOptionCombo: PropTypes.shape({
-        code: PropTypes.string.isRequired,
+        // code: PropTypes.string.isRequired,
         displayName: PropTypes.string.isRequired,
         id: PropTypes.string.isRequired,
     }),

--- a/src/sms-command/FormJ2meParser/Form.js
+++ b/src/sms-command/FormJ2meParser/Form.js
@@ -132,7 +132,6 @@ Form.propTypes = {
                 id: PropTypes.string.isRequired,
             }).isRequired,
             categoryOptionCombo: PropTypes.shape({
-                // code: PropTypes.string.isRequired,
                 displayName: PropTypes.string.isRequired,
                 id: PropTypes.string.isRequired,
             }),

--- a/src/sms-command/FormJ2meParser/Form.js
+++ b/src/sms-command/FormJ2meParser/Form.js
@@ -132,7 +132,7 @@ Form.propTypes = {
                 id: PropTypes.string.isRequired,
             }).isRequired,
             categoryOptionCombo: PropTypes.shape({
-                code: PropTypes.string.isRequired,
+                // code: PropTypes.string.isRequired,
                 displayName: PropTypes.string.isRequired,
                 id: PropTypes.string.isRequired,
             }),

--- a/src/sms-command/FormJ2meParser/FormJ2meParser.js
+++ b/src/sms-command/FormJ2meParser/FormJ2meParser.js
@@ -58,7 +58,7 @@ export const FormJ2meParser = ({ commandId, onAfterChange, onCancel }) => {
     const DE_COC_combination_data = command.dataset.dataSetElements.reduce(
         (curCombinations, { dataElement }) => {
             const categoryOptionCombo =
-                dataElement.categoryCombo?.categoryOptionCombo
+                dataElement.categoryCombo?.categoryOptionCombos
 
             if (!categoryOptionCombo) {
                 return [...curCombinations, { dataElement }]

--- a/src/sms-command/FormJ2meParser/getInitialFormState.js
+++ b/src/sms-command/FormJ2meParser/getInitialFormState.js
@@ -32,24 +32,29 @@ export const getInitialFormState = (command) => {
     const moreThanOneOrgUnitMessage =
         command[FIELD_MORE_THAN_ONE_ORG_UNIT_MESSAGE_NAME]
     const successMessage = command[FIELD_SUCCESS_MESSAGE_NAME]
-    const smsCodes = command[FIELD_SMS_CODES_NAME].reduce(
-        (acc, { code, compulsory, formula, optionId, dataElement }) => {
-            const key =
-                optionId < 10 ? dataElement.id : `${dataElement.id}-${optionId}`
+    const smsCodes = command[FIELD_SMS_CODES_NAME].reduce((acc, payload) => {
+        const {
+            code,
+            compulsory,
+            formula,
+            optionId: optionIdWrapper,
+            dataElement,
+        } = payload
+        const { id: optionId } = optionIdWrapper
+        const key =
+            optionId < 10 ? dataElement.id : `${dataElement.id}-${optionId}`
 
-            const smsCode = { code, compulsory, optionId }
+        const smsCode = { code, compulsory, optionId }
 
-            if (formula) {
-                smsCode.formula = formula
-            }
+        if (formula) {
+            smsCode.formula = formula
+        }
 
-            return {
-                ...acc,
-                [key]: smsCode,
-            }
-        },
-        {}
-    )
+        return {
+            ...acc,
+            [key]: smsCode,
+        }
+    }, {})
     const specialCharacters = command[FIELD_SPECIAL_CHARS_NAME] || []
 
     return {

--- a/src/sms-command/FormJ2meParser/useCommandData.js
+++ b/src/sms-command/FormJ2meParser/useCommandData.js
@@ -10,34 +10,12 @@ export const READ_SMS_COMMAND_KEY_VALUE_PARSER_QUERY = {
     smsCommand: {
         resource: 'smsCommands',
         id: ({ id }) => id,
-        params: () => {
-            const paging = 'false'
-            const fields = [
+        params: () => ({
+            fields: [
                 '*',
-                `dataset [
-                    id,
-                    displayName,
-                    dataSetElements [
-                        dataElement [
-                            id,
-                            displayName,
-                            categoryCombo [
-                                categoryOptionCombos [
-                                    id,
-                                    displayName,
-                                    code
-                                ]
-                            ]
-                        ]
-                    ]
-                ]`,
-            ]
-
-            return {
-                fields: fields.map((field) => field.replace(/(\n|\s)/g, '')),
-                paging,
-            }
-        },
+                `dataset[id,displayName,dataSetElements[dataElement[id,displayName,categoryCombo[categoryOptionCombos[*,id,displayName]]]]]`,
+            ],
+        }),
     },
 }
 

--- a/src/sms-command/FormJ2meParser/useUpdateCommandMutation.js
+++ b/src/sms-command/FormJ2meParser/useUpdateCommandMutation.js
@@ -33,13 +33,13 @@ const updateJ2meParserMutation = {
             command[FIELD_MORE_THAN_ONE_ORG_UNIT_MESSAGE_NAME]
         const successMessage = command[FIELD_SUCCESS_MESSAGE_NAME]
         const specialCharacters = command[FIELD_SPECIAL_CHARS_NAME] || []
-        const smsCodes = Object.entries(command[FIELD_SMS_CODES_NAME]).map(
-            ([id, { code, formula, compulsory, optionId }]) => {
-                const [dataElementId] = id.split('-')
+        const smsCodes = Object.values(command[FIELD_SMS_CODES_NAME]).map(
+            ({ code: codeWrapper, compulsory, optionId, dataElement }) => {
+                const { code, formula } = codeWrapper
                 const formattedSmsCode = {
                     code,
-                    compulsory,
-                    dataElement: { id: dataElementId },
+                    compulsory: !!compulsory,
+                    dataElement,
                 }
 
                 if (formula) {
@@ -77,7 +77,30 @@ const updateJ2meParserMutation = {
 export const useUpdateCommandMutation = ({ id, onAfterChange }) => {
     const engine = useDataEngine()
     const onSubmit = (values) => {
-        const variables = { ...values, id }
+        const variables = {
+            ...values,
+            id,
+            smsCodes:
+                !values.smsCodes || !Object.values(values.smsCodes).length
+                    ? []
+                    : Object.entries(values.smsCodes).map(([key, value]) => {
+                          const [dataElementId, categoryOptionComboId] =
+                              key.split('-')
+
+                          return {
+                              ...(categoryOptionComboId
+                                  ? {
+                                        optionId: { id: categoryOptionComboId },
+                                    }
+                                  : {}),
+                              code: value,
+                              dataElement: {
+                                  id: dataElementId,
+                              },
+                          }
+                      }),
+        }
+
         return engine
             .mutate(updateJ2meParserMutation, { variables })
             .then(onAfterChange)

--- a/src/sms-command/FormKeyValueParser/Form.js
+++ b/src/sms-command/FormKeyValueParser/Form.js
@@ -132,7 +132,6 @@ Form.propTypes = {
                 id: PropTypes.string.isRequired,
             }).isRequired,
             categoryOptionCombo: PropTypes.shape({
-                // code: PropTypes.string.isRequired,
                 displayName: PropTypes.string.isRequired,
                 id: PropTypes.string.isRequired,
             }),

--- a/src/sms-command/FormKeyValueParser/Form.js
+++ b/src/sms-command/FormKeyValueParser/Form.js
@@ -132,7 +132,7 @@ Form.propTypes = {
                 id: PropTypes.string.isRequired,
             }).isRequired,
             categoryOptionCombo: PropTypes.shape({
-                code: PropTypes.string.isRequired,
+                // code: PropTypes.string.isRequired,
                 displayName: PropTypes.string.isRequired,
                 id: PropTypes.string.isRequired,
             }),

--- a/src/sms-command/FormKeyValueParser/FormKeyValueParser.js
+++ b/src/sms-command/FormKeyValueParser/FormKeyValueParser.js
@@ -63,7 +63,7 @@ export const FormKeyValueParser = ({ commandId, onAfterChange, onCancel }) => {
     const DE_COC_combination_data = command.dataset.dataSetElements.reduce(
         (curCombinations, { dataElement }) => {
             const categoryOptionCombo =
-                dataElement.categoryCombo?.categoryOptionCombo
+                dataElement.categoryCombo?.categoryOptionCombos
 
             if (!categoryOptionCombo) {
                 return [...curCombinations, { dataElement }]

--- a/src/sms-command/FormKeyValueParser/getInitialFormState.js
+++ b/src/sms-command/FormKeyValueParser/getInitialFormState.js
@@ -32,24 +32,29 @@ export const getInitialFormState = (command) => {
     const moreThanOneOrgUnitMessage =
         command[FIELD_MORE_THAN_ONE_ORG_UNIT_MESSAGE_NAME]
     const successMessage = command[FIELD_SUCCESS_MESSAGE_NAME]
-    const smsCodes = command[FIELD_SMS_CODES_NAME].reduce(
-        (acc, { code, compulsory, formula, optionId, dataElement }) => {
-            const key =
-                optionId < 10 ? dataElement.id : `${dataElement.id}-${optionId}`
+    const smsCodes = command[FIELD_SMS_CODES_NAME].reduce((acc, payload) => {
+        const {
+            code,
+            compulsory,
+            formula,
+            optionId: optionIdWrapper,
+            dataElement,
+        } = payload
+        const { id: optionId } = optionIdWrapper
+        const key =
+            optionId < 10 ? dataElement.id : `${dataElement.id}-${optionId}`
 
-            const smsCode = { code, compulsory, optionId }
+        const smsCode = { code, compulsory, optionId }
 
-            if (formula) {
-                smsCode.formula = formula
-            }
+        if (formula) {
+            smsCode.formula = formula
+        }
 
-            return {
-                ...acc,
-                [key]: smsCode,
-            }
-        },
-        {}
-    )
+        return {
+            ...acc,
+            [key]: smsCode,
+        }
+    }, {})
     const specialCharacters = command[FIELD_SPECIAL_CHARS_NAME] || []
 
     return {

--- a/src/sms-command/FormKeyValueParser/useCommandData.js
+++ b/src/sms-command/FormKeyValueParser/useCommandData.js
@@ -10,34 +10,12 @@ export const READ_SMS_COMMAND_KEY_VALUE_PARSER_QUERY = {
     smsCommand: {
         resource: 'smsCommands',
         id: ({ id }) => id,
-        params: () => {
-            const paging = 'false'
-            const fields = [
+        params: () => ({
+            fields: [
                 '*',
-                `dataset [
-                    id,
-                    displayName,
-                    dataSetElements [
-                        dataElement [
-                            id,
-                            displayName,
-                            categoryCombo [
-                                categoryOptionCombos [
-                                    id,
-                                    displayName,
-                                    code
-                                ]
-                            ]
-                        ]
-                    ]
-                ]`,
-            ]
-
-            return {
-                fields: fields.map((field) => field.replace(/(\n|\s)/g, '')),
-                paging,
-            }
-        },
+                `dataset[id,displayName,dataSetElements[dataElement[id,displayName,categoryCombo[categoryOptionCombos[*,id,displayName]]]]]`,
+            ],
+        }),
     },
 }
 

--- a/src/sms-command/FormKeyValueParser/useUpdateCommandMutation.js
+++ b/src/sms-command/FormKeyValueParser/useUpdateCommandMutation.js
@@ -33,13 +33,13 @@ const updateKeyValueParserMutation = {
             command[FIELD_MORE_THAN_ONE_ORG_UNIT_MESSAGE_NAME]
         const successMessage = command[FIELD_SUCCESS_MESSAGE_NAME]
         const specialCharacters = command[FIELD_SPECIAL_CHARS_NAME] || []
-        const smsCodes = Object.entries(command[FIELD_SMS_CODES_NAME]).map(
-            ([id, { code, formula, compulsory, optionId }]) => {
-                const [dataElementId] = id.split('-')
+        const smsCodes = Object.values(command[FIELD_SMS_CODES_NAME]).map(
+            ({ code: codeWrapper, compulsory, optionId, dataElement }) => {
+                const { code, formula } = codeWrapper
                 const formattedSmsCode = {
                     code,
-                    compulsory,
-                    dataElement: { id: dataElementId },
+                    compulsory: !!compulsory,
+                    dataElement,
                 }
 
                 if (formula) {
@@ -54,7 +54,7 @@ const updateKeyValueParserMutation = {
             }
         )
 
-        return {
+        const params = {
             [FIELD_COMMAND_NAME]: name,
             [FIELD_PARSER_NAME]: parserType,
             [FIELD_DATA_SET_NAME]: dataSetId,
@@ -71,13 +71,38 @@ const updateKeyValueParserMutation = {
             [FIELD_SPECIAL_CHARS_NAME]: specialCharacters,
             [FIELD_SMS_CODES_NAME]: smsCodes,
         }
+
+        return params
     },
 }
 
 export const useUpdateCommandMutation = ({ id, onAfterChange }) => {
     const engine = useDataEngine()
     const onSubmit = (values) => {
-        const variables = { ...values, id }
+        const variables = {
+            ...values,
+            id,
+            smsCodes:
+                !values.smsCodes || !Object.values(values.smsCodes).length
+                    ? []
+                    : Object.entries(values.smsCodes).map(([key, value]) => {
+                          const [dataElementId, categoryOptionComboId] =
+                              key.split('-')
+
+                          return {
+                              ...(categoryOptionComboId
+                                  ? {
+                                        optionId: { id: categoryOptionComboId },
+                                    }
+                                  : {}),
+                              code: value,
+                              dataElement: {
+                                  id: dataElementId,
+                              },
+                          }
+                      }),
+        }
+
         return engine
             .mutate(updateKeyValueParserMutation, { variables })
             .then(onAfterChange)

--- a/src/sms-command/FormKeyValueParser/useUpdateCommandMutation.js
+++ b/src/sms-command/FormKeyValueParser/useUpdateCommandMutation.js
@@ -54,7 +54,7 @@ const updateKeyValueParserMutation = {
             }
         )
 
-        const params = {
+        return {
             [FIELD_COMMAND_NAME]: name,
             [FIELD_PARSER_NAME]: parserType,
             [FIELD_DATA_SET_NAME]: dataSetId,
@@ -71,8 +71,6 @@ const updateKeyValueParserMutation = {
             [FIELD_SPECIAL_CHARS_NAME]: specialCharacters,
             [FIELD_SMS_CODES_NAME]: smsCodes,
         }
-
-        return params
     },
 }
 


### PR DESCRIPTION
Fixes a bug in key value pair & J2ME sms commands which rendered the wrong input fields for short codes.
Impacts covid vaccination sms commands