### PR TITLE
fix: hide pagination when pageCount==0

### DIFF
--- a/src/shared/components/pagination/Pagination.js
+++ b/src/shared/components/pagination/Pagination.js
@@ -21,6 +21,10 @@ export const Pagination = ({ page, pageCount, pageSize, total }) => {
         setQueryParams({ pageSize, page: 1 })
     }
 
+    if (pageCount === 0) {
+        return null
+    }
+
     return (
         <div className={styles.container}>
             <div className={styles.verticalAlign}>


### PR DESCRIPTION
Fix for [BETA-50](https://dhis2.atlassian.net/browse/BETA-50)

Prevents app from erroring out when there are no received/sent messages (issue was caused by pagination, so this is hidden when pageCount===0)

Note the api is returning `pageCount: 0` and `page: 1` which is why the error occurs (we had a SingleSelect where we set the selected page as `page` and then it could not select that as the pageCount is 0).

With this fix, we just don't render anything if the api says the pageCount is 0. This works even when you delete the values from the table because the query is re-executed and you get the updated pageCount.

**Before**
App errors out (see ticket)
 
**After**
Table without paginator 

<img width="1147" alt="image" src="https://user-images.githubusercontent.com/18490902/233641363-dba18ab6-761d-4a28-ae77-05b3c8320afb.png">


[BETA-50]: https://dhis2.atlassian.net/browse/BETA-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ