### PR TITLE
fix: remove user from smsInbound request [DHIS2-18261]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-03-14T12:02:04.283Z\n"
-"PO-Revision-Date: 2024-03-14T12:02:04.283Z\n"
+"POT-Creation-Date: 2024-12-02T14:06:12.331Z\n"
+"PO-Revision-Date: 2024-12-02T14:06:12.332Z\n"
 
 msgid "Are you sure you want to cancel? Unsaved changes will be lost"
 msgstr "Are you sure you want to cancel? Unsaved changes will be lost"
@@ -463,12 +463,6 @@ msgstr "Phone number"
 
 msgid "Status"
 msgstr "Status"
-
-msgid "Sender"
-msgstr "Sender"
-
-msgid "Unknown"
-msgstr "Unknown"
 
 msgid "Something went wrong whilst loading received SMSes"
 msgstr "Something went wrong whilst loading received SMSes"

--- a/src/sms-inbound/ReceivedSmsTable/ReceivedSmsTable.js
+++ b/src/sms-inbound/ReceivedSmsTable/ReceivedSmsTable.js
@@ -21,7 +21,6 @@ export const ReceivedSmsTable = ({
             i18n.t('Message'),
             i18n.t('Phone number'),
             i18n.t('Status'),
-            i18n.t('Sender'),
             i18n.t('Received'),
         ]}
         rowRenderFn={(message) => (
@@ -33,10 +32,6 @@ export const ReceivedSmsTable = ({
                     </span>
                 </TableCell>
                 <TableCell>{translations[message.smsstatus]}</TableCell>
-                <TableCell>
-                    {message.user?.userCredentials?.username ||
-                        i18n.t('Unknown')}
-                </TableCell>
                 <TableCell>
                     <Date date={message.receiveddate} />
                     {', '}

--- a/src/sms-inbound/ViewReceivedSmsList/ViewReceivedSmsList.js
+++ b/src/sms-inbound/ViewReceivedSmsList/ViewReceivedSmsList.js
@@ -23,14 +23,7 @@ const parseParams = ({ page, pageSize, phoneNumber, status }) => {
     const params = {
         page,
         pageSize,
-        fields: [
-            'id',
-            'text',
-            'originator',
-            'smsstatus',
-            'user[userCredentials[username]]', // sender
-            'receiveddate',
-        ],
+        fields: ['id', 'text', 'originator', 'smsstatus', 'receiveddate'],
         order: 'receiveddate:desc',
     }
 


### PR DESCRIPTION
This ticket ([DHIS2-18261](https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-18261)) was to remove references to user.userCredential, but as it turns out `user` is not being returned for sms/inbound, and even if it were being returned it would not represent the sender of the sms (as we were showing in the app), but rather the creator of the metadata (I talked this over with Jan B. in slack conversation on team channel: https://dhis2.slack.com/archives/C05LL17C8AJ/p1733145814548449)
 
Consequently, I have just removed the reference to the user field and removed the relevant column

**Before**
<img width="1150" alt="image" src="https://github.com/user-attachments/assets/84a09848-4839-4b34-8834-e66d1ef00382">


**After**
<img width="1398" alt="image" src="https://github.com/user-attachments/assets/af4e67e1-eb51-49c1-87fd-924b883889bd">

(I'm not addressing any of the other obvious UI issues like the lack of margins on the search fields 🙈)

[DHIS2-18261]: https://dhis2.atlassian.net/browse/DHIS2-18261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ